### PR TITLE
[IMPROVEMENT] improve off-chain oracle return and make FLAT upgradeable

### DIFF
--- a/contracts/v8/FLAT.sol
+++ b/contracts/v8/FLAT.sol
@@ -8,15 +8,15 @@
 
 pragma solidity 0.8.9;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 
 import "./interfaces/IClerk.sol";
 
 /// @title FLAT - A stablecoin backed by a basket of farmable assets.
 // solhint-disable not-rely-on-time
-contract FLAT is ERC20("FLAT", "FLAT"), Ownable {
+contract FLAT is ERC20Upgradeable, OwnableUpgradeable {
   /// @dev Event
   event LogReplenish(address indexed market, IClerk indexed vault, uint256 amount);
   event LogSetMaxMintBps(uint256 _prevMaxMintBps, uint256 _newMaxMintBps);
@@ -36,9 +36,12 @@ contract FLAT is ERC20("FLAT", "FLAT"), Ownable {
   /// @notice Contructor to initialize the contract
   /// @param _initMintRange The cool down period between mints
   /// @param _initMaxMintBps The % of FLAT that can be minted
-  constructor(uint256 _initMintRange, uint256 _initMaxMintBps) {
+  function initialize(uint256 _initMintRange, uint256 _initMaxMintBps) external initializer {
     require(_initMintRange >= 6 hours, "bad _initMintRange");
     require(_initMaxMintBps <= 3000, "bad _initMaxMintBps");
+
+    OwnableUpgradeable.__Ownable_init();
+    ERC20Upgradeable.__ERC20_init("FLAT", "FLAT");
 
     mintRange = _initMintRange;
     maxMintBps = _initMaxMintBps;

--- a/contracts/v8/oracles/CompositeOracle.sol
+++ b/contracts/v8/oracles/CompositeOracle.sol
@@ -130,12 +130,11 @@ contract CompositeOracle is IOracle, Initializable, AccessControlUpgradeable {
     // Get valid oracle sources
     uint256 _validSourceCount = 0;
     for (uint256 _idx = 0; _idx < _candidateSourceCount; _idx++) {
-      try primarySources[_token][_idx].get(oracleDatas[_token][_idx]) returns (
-        bool, /*isSuccess*/
-        uint256 price
-      ) {
-        _unsortedPrices[_validSourceCount] = price;
-        _prices[_validSourceCount++] = price;
+      try primarySources[_token][_idx].get(oracleDatas[_token][_idx]) returns (bool isSuccess, uint256 price) {
+        if (isSuccess) {
+          _unsortedPrices[_validSourceCount] = price;
+          _prices[_validSourceCount++] = price;
+        }
       } catch {}
     }
     require(_validSourceCount > 0, "CompositeOracle::_get::no valid source");

--- a/contracts/v8/oracles/OffChainOracle.sol
+++ b/contracts/v8/oracles/OffChainOracle.sol
@@ -62,8 +62,8 @@ contract OffChainOracle is IOracle, Initializable, AccessControlUpgradeable {
   /// @dev Get the exchange rate
   function get(bytes calldata _data) public view override returns (bool, uint256) {
     (address _token0, address _token1) = abi.decode(_data, (address, address));
-    (uint256 _price, ) = _getPrice(_token0, _token1);
-    return (true, _price);
+    (uint256 _price, uint256 _lastUpdate) = _getPrice(_token0, _token1);
+    return (_lastUpdate >= block.timestamp - 1 days, _price);
   }
 
   /// @dev Return "Offchain" as a name

--- a/tests/helpers/fixtures/FlatMarket.ts
+++ b/tests/helpers/fixtures/FlatMarket.ts
@@ -15,6 +15,7 @@ import {
   MockWBNB,
   MockWBNB__factory,
   FLAT__factory,
+  FLAT,
 } from "../../../typechain/v8";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { smockit, MockContract } from "@eth-optimism/smock";
@@ -56,7 +57,7 @@ export async function flatMarketUnitTestFixture(
 
   // Deploy FLAT
   const FLAT = (await ethers.getContractFactory("FLAT", deployer)) as FLAT__factory;
-  const flat = await FLAT.deploy(24 * 60 * 60, 1500);
+  const flat = (await upgrades.deployProxy(FLAT, [24 * 60 * 60, 1500])) as FLAT;
   await flat.deployed();
   const mockedFlat = await smockit(flat);
 

--- a/tests/helpers/fixtures/TreasuryHolder.ts
+++ b/tests/helpers/fixtures/TreasuryHolder.ts
@@ -63,7 +63,7 @@ export async function treasuryHolderUnitTestFixture(
   await wbnb.deployed();
 
   const Flat = new FLAT__factory(deployer);
-  const flat = await Flat.deploy(6 * hours, 3000);
+  const flat = (await upgrades.deployProxy(Flat, [6 * hours, 3000])) as FLAT;
   await flat.deployed();
 
   await flat.mint(await deployer.getAddress(), ethers.utils.parseEther("1000000000"));

--- a/tests/unit/Flat.test.ts
+++ b/tests/unit/Flat.test.ts
@@ -35,7 +35,7 @@ describe("FLAT", async () => {
     clerk = (await upgrades.deployProxy(Clerk, [wbnb.address])) as Clerk;
 
     const FLAT = (await ethers.getContractFactory("FLAT")) as FLAT__factory;
-    flat = await FLAT.deploy(MINT_RANGE, MAX_MINT_BPS);
+    flat = (await upgrades.deployProxy(FLAT, [MINT_RANGE, MAX_MINT_BPS])) as FLAT;
 
     flatAsAlice = FLAT__factory.connect(flat.address, alice);
   }
@@ -53,8 +53,10 @@ describe("FLAT", async () => {
     context("when bad init values", async () => {
       it("should revert", async () => {
         const FLAT = (await ethers.getContractFactory("FLAT")) as FLAT__factory;
-        await expect(FLAT.deploy(ethers.constants.Zero, MAX_MINT_BPS)).to.be.revertedWith("bad _initMintRange");
-        await expect(FLAT.deploy(MINT_RANGE, 9000)).to.be.revertedWith("bad _initMaxMintBps");
+        await expect(upgrades.deployProxy(FLAT, [ethers.constants.Zero, MAX_MINT_BPS])).to.be.revertedWith(
+          "bad _initMintRange"
+        );
+        await expect(upgrades.deployProxy(FLAT, [MINT_RANGE, 9000])).to.be.revertedWith("bad _initMaxMintBps");
       });
     });
   });


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE  -->
## Description
This is an improve pr for improving off chain oracle by adding success case based on a price stale, and make a FLAT token upgradeable for the future features.
## Purpose of this change
<!--- Why is this change required? What problem does it solve? -->
## Is this PR Breaking Changes?
- [ ] Y
- [x] N
## Changes:
- make FLAT contract upgradeable
- add success/ non-success case for compositeOracle, if success if false, then there will be no price state assignment
- add a case for offchainOracle when the price is stale