### PR TITLE
[FIX] Yield Strategy and Composite Oracle

### DIFF
--- a/contracts/v8/TreasuryHolder.sol
+++ b/contracts/v8/TreasuryHolder.sol
@@ -85,6 +85,7 @@ contract TreasuryHolder is OwnableUpgradeable, ITreasuryHolderCallback {
   /// @notice set treasuryEOA
   /// @param _treasuryEOA address of the EOA
   function setTreasuryEOA(address _treasuryEOA) external onlyOwner {
+    require(_treasuryEOA != address(0), "TreasuryHolder::setTreasuryEOA:: eoa cannot be address(0)");
     treasuryEOA = _treasuryEOA;
 
     emit LogSetTreasuryEOA(treasuryEOA);
@@ -93,7 +94,6 @@ contract TreasuryHolder is OwnableUpgradeable, ITreasuryHolderCallback {
   /// @notice function to withdraw a surplus + liquidation share to the EOA address
   function withdrawSurplus() external onlyOwner {
     require(totalBadDebtValue == 0, "TreasuryHolder::withdrawSurplus:: there are still bad debt markets");
-    require(treasuryEOA != address(0), "TreasuryHolder::withdrawSurplus:: treasuryEOA is address(0)");
 
     uint256 _balanceOf = clerk.balanceOf(flat, address(this));
 

--- a/contracts/v8/interfaces/IMasterBarista.sol
+++ b/contracts/v8/interfaces/IMasterBarista.sol
@@ -12,6 +12,8 @@ interface IMasterBarista {
 
   function pendingLatte(address _stakeToken, address _user) external view returns (uint256);
 
+  function activeLatte() external view returns (address);
+
   function userInfo(address _stakeToken, address _user)
     external
     view

--- a/contracts/v8/mock/MockLatteSwapYield.sol
+++ b/contracts/v8/mock/MockLatteSwapYield.sol
@@ -20,11 +20,17 @@ contract MockMasterBaristaForLatteSwapYield is IMasterBarista {
     address fundedBy;
   }
 
+  address public override activeLatte;
+
   mapping(address => mapping(address => UserInfo)) public override userInfo;
 
   function poolLength() external view returns (uint256) {}
 
   function pendingLatte(address _stakeToken, address _user) external view returns (uint256) {}
+
+  function setActiveLatte(address _activeLatte) external {
+    activeLatte = _activeLatte;
+  }
 
   function setUserInfo(
     address _token,

--- a/contracts/v8/oracles/CompositeOracle.sol
+++ b/contracts/v8/oracles/CompositeOracle.sol
@@ -56,7 +56,7 @@ contract CompositeOracle is IOracle, Initializable, AccessControlUpgradeable {
     maxPriceDeviation = 3e18;
 
     require(
-      _timeDelay >= 15 minutes && _timeDelay <= 2 days,
+      _timeDelay >= 15 minutes && _timeDelay <= 1 hours,
       "CompositeOracle::setMultiPrimarySources::invalid time delay"
     );
     timeDelay = _timeDelay;
@@ -142,7 +142,7 @@ contract CompositeOracle is IOracle, Initializable, AccessControlUpgradeable {
 
   /// @dev update the current price for the token using the nextPrice as well as using the newly fetched price as a new next price
   /// @param _datas array of encoded data
-  function setPrices(bytes[] calldata _datas) public {
+  function setPrices(bytes[] calldata _datas) external {
     for (uint256 _idx = 0; _idx < _datas.length; _idx++) {
       address _token = abi.decode(_datas[_idx], (address));
       Price storage _priceMeta = prices[_token];

--- a/contracts/v8/strategies/yield/LatteSwapYieldStrategy.sol
+++ b/contracts/v8/strategies/yield/LatteSwapYieldStrategy.sol
@@ -66,7 +66,7 @@ contract LatteSwapYieldStrategy is IStrategy, OwnableUpgradeable, PausableUpgrad
     latteBooster = _latteBooster;
     stakingToken = _stakingToken;
     masterBarista = IMasterBarista(IBooster(latteBooster).masterBarista());
-    rewardToken = IERC20Upgradeable(IBooster(latteBooster).latte());
+    rewardToken = IERC20Upgradeable(masterBarista.activeLatte());
     decimals = IToken(address(_stakingToken)).decimals();
     to18ConversionFactor = 10**(18 - decimals);
 
@@ -163,7 +163,11 @@ contract LatteSwapYieldStrategy is IStrategy, OwnableUpgradeable, PausableUpgrad
 
   // Withdraw all assets in the safest way possible. This shouldn't fail.
   function exit(uint256 balance) external override onlyGovernance whenNotPaused returns (int256 _amountAdded) {
-    latteBooster.emergencyWithdraw(address(stakingToken));
+    (uint256 _stakedBalance, , , ) = masterBarista.userInfo(address(stakingToken), address(this));
+
+    if (_stakedBalance > 0) {
+      latteBooster.emergencyWithdraw(address(stakingToken));
+    }
 
     uint256 _stakingBalance = stakingToken.balanceOf(address(this));
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@latteswap/latteswap-contract",
+  "name": "@latteswap/latteswap-flat",
   "scripts": {
     "mainnetfork": "source ./start_mainnet_fork_node.sh",
     "copy-dts-typechain": "npx copyfiles -u 1 \"typechain/**/*.d.ts\" compiled-typechain",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@eth-optimism/smock": "^1.1.10",
     "@ethersproject/bignumber": "^5.0.14",
-    "@latteswap/latteswap-contract-config": "^1.2.0",
+    "@latteswap/latteswap-contract-config": "^1.6.0-rc.7",
     "@nomiclabs/ethereumjs-vm": "^4.2.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-etherscan": "^2.1.1",
@@ -77,7 +77,8 @@
   "files": [
     "typechain",
     "artifacts",
-    "contracts"
+    "contracts",
+    "compiled-typechain"
   ],
   "dependencies": {
     "@defi-wonderland/smock": "^2.0.7",

--- a/tests/helpers/fixtures/Clerk.ts
+++ b/tests/helpers/fixtures/Clerk.ts
@@ -140,6 +140,7 @@ export async function clerkIntegrationTestFixture(
     deployer
   );
   const masterBarista: MockContract<MockMasterBaristaForLatteSwapYield> = await MasterBarista.deploy();
+  await masterBarista.setActiveLatte(latteToken.address);
 
   // Mint LATTE for testing purpose
   await latteToken.mint(await deployer.getAddress(), ethers.utils.parseEther("888888888"));

--- a/tests/helpers/fixtures/CompositeOracle.ts
+++ b/tests/helpers/fixtures/CompositeOracle.ts
@@ -3,6 +3,7 @@ import { BigNumber, Signer, Wallet } from "ethers";
 import { ethers, upgrades } from "hardhat";
 import { CompositeOracle, CompositeOracle__factory, MockOracle, SimpleToken } from "../../../typechain/v8";
 import { FakeContract, MockContract, smock } from "@defi-wonderland/smock";
+import { duration, increaseTimestamp } from "../time";
 
 export interface ICompositeOracleDTO {
   compositeOracle: CompositeOracle;
@@ -17,7 +18,12 @@ export async function compositeOracleUnitTestFixture(
   const [deployer] = await ethers.getSigners();
 
   const CompositeOracle = new CompositeOracle__factory(deployer);
-  const compositeOracle = await upgrades.deployProxy(CompositeOracle, []);
+  const compositeOracle = await upgrades.deployProxy(CompositeOracle, [
+    15 * 60, // 15 minutes
+  ]);
+
+  // reset delay for for each case
+  await increaseTimestamp(duration.minutes(BigNumber.from("15"))); // 7 days
 
   const simpleToken = await (await ethers.getContractFactory("SimpleToken")).deploy();
 

--- a/tests/helpers/fixtures/FlatMarket.ts
+++ b/tests/helpers/fixtures/FlatMarket.ts
@@ -5,20 +5,18 @@ import {
   Clerk__factory,
   SimpleToken__factory,
   Clerk,
-  CompositeOracle__factory,
-  CompositeOracle,
   SimpleToken,
   FlatMarket,
   FlatMarketConfig,
   FlatMarketConfig__factory,
   FlatMarket__factory,
-  MockWBNB,
-  MockWBNB__factory,
   FLAT__factory,
   FLAT,
+  CompositeOracle__factory,
 } from "../../../typechain/v8";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { smockit, MockContract } from "@eth-optimism/smock";
+import { MockWBNB__factory } from "../../../typechain/v6";
 
 export type IFlatMarketUnitDTO = {
   deployer: SignerWithAddress;
@@ -69,7 +67,7 @@ export async function flatMarketUnitTestFixture(
 
   // Deploy mocked composit oracle
   const CompositeOracle = (await ethers.getContractFactory("CompositeOracle", deployer)) as CompositeOracle__factory;
-  const compositeOracle = await upgrades.deployProxy(CompositeOracle, []);
+  const compositeOracle = await upgrades.deployProxy(CompositeOracle, [15 * 60]);
   await compositeOracle.deployed();
   const mockedCompositeOracle = await smockit(compositeOracle);
 

--- a/tests/helpers/fixtures/LatteSwapLiquidationStrategy.ts
+++ b/tests/helpers/fixtures/LatteSwapLiquidationStrategy.ts
@@ -7,17 +7,19 @@ import {
   SimpleToken__factory,
   LatteSwapLiquidationStrategy__factory,
   LatteSwapLiquidationStrategy,
-  LatteSwapPair__factory,
-  LatteSwapPair,
-  MockWBNB__factory,
-  LatteSwapFactory,
-  LatteSwapRouter,
-  LatteSwapFactory__factory,
-  LatteSwapRouter__factory,
 } from "../../../typechain/v8";
 import { BigNumber, constants, Wallet } from "ethers";
 import { MockProvider } from "ethereum-waffle";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { MockWBNB__factory } from "@latteswap/latteswap-contract/compiled-typechain";
+import {
+  LatteSwapFactory,
+  LatteSwapFactory__factory,
+  LatteSwapPair,
+  LatteSwapPair__factory,
+  LatteSwapRouter,
+  LatteSwapRouter__factory,
+} from "../../../typechain/v6";
 
 export interface ILatteSwapLiquidationStrategyDTO {
   latteSwapLiquidationStrategy: LatteSwapLiquidationStrategy;

--- a/tests/helpers/fixtures/LatteSwapYieldStrategy.ts
+++ b/tests/helpers/fixtures/LatteSwapYieldStrategy.ts
@@ -52,6 +52,7 @@ export async function latteSwapYieldStrategyUnitTestFixture(
     deployer
   );
   const masterBarista: MockContract<MockMasterBaristaForLatteSwapYield> = await MasterBarista.deploy();
+  await masterBarista.setActiveLatte(latteToken.address);
 
   // Mint LATTE for testing purpose
   await latteToken.mint(await deployer.getAddress(), ethers.utils.parseEther("888888888"));

--- a/tests/integrations/Clerk.test.ts
+++ b/tests/integrations/Clerk.test.ts
@@ -804,6 +804,15 @@ describe("Clerk", () => {
             ethers.utils.parseEther("1")
           );
           expect(await stakingToken.balanceOf(booster.address)).to.eq(ethers.utils.parseEther("1"));
+          // MOCK master barista storages so that it can harvest
+          await masterBarista.setVariable("userInfo", {
+            [stakingToken.address]: {
+              [latteSwapPoolStrategy.address]: {
+                amount: ethers.utils.parseEther("1").toString(),
+                fundedBy: booster.address,
+              },
+            },
+          });
           await clerk.setStrategy(stakingToken.address, constants.AddressZero);
           expect(await stakingToken.balanceOf(booster.address)).to.eq(ethers.utils.parseEther("0"));
           expect(await stakingToken.balanceOf(clerk.address)).to.eq(ethers.utils.parseEther("1"));

--- a/tests/integrations/LatteSwapLiquidateStrategy.test.ts
+++ b/tests/integrations/LatteSwapLiquidateStrategy.test.ts
@@ -2,17 +2,11 @@ import { ethers, waffle } from "hardhat";
 import chai from "chai";
 import { solidity } from "ethereum-waffle";
 import { latteSwapLiquidationStrategyIntegrationTestFixture } from "../helpers";
-import {
-  Clerk,
-  LatteSwapLiquidationStrategy,
-  SimpleToken,
-  LatteSwapFactory,
-  LatteSwapPair,
-  LatteSwapRouter,
-} from "../../typechain/v8";
+import { Clerk, LatteSwapLiquidationStrategy, SimpleToken } from "../../typechain/v8";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { BigNumber } from "ethers";
 import { deploy } from "@openzeppelin/hardhat-upgrades/dist/utils";
+import { LatteSwapFactory, LatteSwapPair, LatteSwapRouter } from "../../typechain/v6";
 
 chai.use(solidity);
 const { expect } = chai;

--- a/tests/unit/CompositeOracle.test.ts
+++ b/tests/unit/CompositeOracle.test.ts
@@ -42,11 +42,11 @@ describe("CompositeOracle", () => {
             shouldRevert: false,
           },
           {
-            timeDelay: 24 * 60 * 60 * 2 + 1, // 2 days + 1 second
+            timeDelay: 60 * 60 + 1, // 1 hour + 1 second
             shouldRevert: true,
           },
           {
-            timeDelay: 24 * 60 * 60 * 2, // 2 days
+            timeDelay: 60 * 60, // 1 hour
             shouldRevert: false,
           },
         ];

--- a/tests/unit/Flat.test.ts
+++ b/tests/unit/Flat.test.ts
@@ -3,7 +3,8 @@ import chai from "chai";
 import { solidity } from "ethereum-waffle";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import * as timeHelpers from "../helpers/time";
-import { Clerk, Clerk__factory, FLAT, FLAT__factory, MockWBNB, MockWBNB__factory } from "../../typechain/v8";
+import { Clerk, Clerk__factory, FLAT, FLAT__factory } from "../../typechain/v8";
+import { MockWBNB, MockWBNB__factory } from "../../typechain/v6";
 
 chai.use(solidity);
 const { expect } = chai;

--- a/tests/unit/TreasuryHolder.test.ts
+++ b/tests/unit/TreasuryHolder.test.ts
@@ -119,6 +119,21 @@ describe("TreasuryHolder", () => {
     });
   });
 
+  describe("#setTreasuryEOA", () => {
+    context("if treasury EOA is address(0)", () => {
+      it("should revert", async () => {
+        await expect(treasuryHolder.setTreasuryEOA(constants.AddressZero)).to.be.revertedWith(
+          "TreasuryHolder::setTreasuryEOA:: eoa cannot be address(0)"
+        );
+      });
+    });
+
+    it("should be able to change the treasuryEOA", async () => {
+      await treasuryHolder.setTreasuryEOA(carol.address);
+      expect(await treasuryHolder.treasuryEOA()).to.eq(carol.address);
+    });
+  });
+
   describe("#withdrawSurplus()", () => {
     context("if there is a bad debt", () => {
       it("should revert", async () => {
@@ -127,15 +142,6 @@ describe("TreasuryHolder", () => {
 
         await expect(treasuryHolder.withdrawSurplus()).to.be.revertedWith(
           "TreasuryHolder::withdrawSurplus:: there are still bad debt markets"
-        );
-      });
-    });
-
-    context("if treasury EOA is address(0)", () => {
-      it("should revert", async () => {
-        await treasuryHolder.setTreasuryEOA(constants.AddressZero);
-        await expect(treasuryHolder.withdrawSurplus()).to.be.revertedWith(
-          "TreasuryHolder::withdrawSurplus:: treasuryEOA is address(0)"
         );
       });
     });

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noUnusedLocals": false,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "module": "commonjs",
+    "lib": ["es6", "es2017", "dom"],
+    "target": "es5",
+    "types": ["@types/node", "@types/chai", "@types/mocha"],
+    "typeRoots": ["./node_modules/@types", "./types", "./typechain"],
+    "outDir": "compiled-typechain",
+    "declaration": true
+  },
+  "include": [
+    "./typechain/**/*"
+  ],
+  "exclude": ["node_modules", "build", "cache", "artifacts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,10 +966,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
-"@latteswap/latteswap-contract-config@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@latteswap/latteswap-contract-config/-/latteswap-contract-config-1.2.0.tgz#3d295e3f98f5544bc88e68024bd129b9790a5d91"
-  integrity sha512-glcog/6VTIN/IO2AXotqEvUwamM1n86WbN2njwZHxnCA52dGdeHYhpI/OGbJHHCEhscMZEG5TfZyLjFKLcF4Tg==
+"@latteswap/latteswap-contract-config@^1.6.0-rc.7":
+  version "1.6.0-rc.7"
+  resolved "https://registry.yarnpkg.com/@latteswap/latteswap-contract-config/-/latteswap-contract-config-1.6.0-rc.7.tgz#9c6093350f69499c079a620536b07c371c4450bc"
+  integrity sha512-ezp9hnOfohVGcrhZI5745KRPNLbIITi23pQQ59C5WwLfs1gnHB/nxdN5MCK8TLNjKGkAWq8E1iJGp/HcnjfkjQ==
 
 "@latteswap/latteswap-contract@^2.2.0":
   version "2.2.0"


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE  -->
## Description
This PR fix/improve the following
- for latteswapYieldStrategy, 
    - `emergencyWithdraw` needs to check the balance, if the balance is 0, omit the function call, otherwise it will be reverted (since if the balance = 0, funder will be address(0) as well)
    - during an initialization, need to use activeLatte rather than latte since the latte() is a V1
- for compositeOracle, add timeDelay mechanis, to delay the price output to be (15 - 2 days) earlier
## Purpose of this change
to fix the bugs (for LatteSwapYieldStrategy) and to improve the return price
## Is this PR Breaking Changes?
- [ ] Y
- [x] N
## Changes:
- fix LatteSwapYieldStrategy (see the description)
- improve compositeOracle (see the description)